### PR TITLE
Set the item width to an integer

### DIFF
--- a/Source/Column.swift
+++ b/Source/Column.swift
@@ -34,7 +34,7 @@ extension Column {
         let aspectRatio = itemSize.height / itemSize.width
         let itemRect = CGRect(x: frame.minX,
             y: bottomEdge,
-            width: width,
+            width: floor(width),
             height: floor(width * aspectRatio))
 
         let itemAttributes = UICollectionViewLayoutAttributes(forCellWithIndexPath: indexPath)


### PR DESCRIPTION
If this wasn't an integer, but the height was, it led to inaccurate cell 
sizes. We were seeing the background bleed through on the right hand side. If
we remove the floor for the height, we would see the background on the right
and the bottom. Flooring both the width and the height ensures that the cells
are sized properly.

https://www.youtube.com/watch?v=TceQHJ2CsFY
